### PR TITLE
Fix the DNS bug

### DIFF
--- a/src/NativeDns.cpp
+++ b/src/NativeDns.cpp
@@ -49,6 +49,13 @@ void DNSClient::fnet_dns_callback(const fnet_dns_resolved_addr_t* addr_list, lon
 
 int DNSClient::getHostByName(const char* aHostname, IPAddress& aResult, uint16_t timeout)
 {
+    // See if it's a numeric IP address
+    if (inet_aton(aHostname, aResult)) 
+    {
+      // It is, our work here is done
+      return 1;
+    }
+	
     resolveDone = 0;
     struct fnet_dns_params dns_params = {
         .dns_server_addr = {


### PR DESCRIPTION
Fix the bug when host is actually an IP Address.

See the issue [**Socket.io client on Teensy Native Ethernet not working on Websockets_Generic** #12](https://github.com/khoih-prog/WebSockets_Generic/issues/12)